### PR TITLE
Fix run status handling and add existing run status retrieval

### DIFF
--- a/lib/gpt_agent.ex
+++ b/lib/gpt_agent.ex
@@ -122,6 +122,17 @@ defmodule GptAgent do
   end
 
   @impl true
+  def handle_continue({:check_run_status, nil}, state) do
+    log("No run in progress, not checking run status")
+    noreply(state)
+  end
+
+  @impl true
+  def handle_continue({:check_run_status, run_id}, state) do
+    handle_info({:check_run_status, run_id}, state)
+  end
+
+  @impl true
   def handle_continue(:read_messages, %__MODULE__{} = state) do
     url =
       "/v1/threads/#{state.thread_id}/messages?order=asc" <>

--- a/lib/gpt_agent.ex
+++ b/lib/gpt_agent.ex
@@ -347,11 +347,19 @@ defmodule GptAgent do
     |> noreply()
   end
 
-  defp handle_run_status(_status, id, _response, %__MODULE__{} = state) do
+  defp handle_run_status(status, id, _response, %__MODULE__{} = state)
+       when status in ~w(queued in_progress) do
     log("Run ID #{inspect(id)} not completed")
     Process.send_after(self(), {:check_run_status, id}, heartbeat_interval_ms())
     log("Will check run status in #{heartbeat_interval_ms()} ms")
-    noreply(state)
+    noreply(%{state | running?: true})
+  end
+
+  defp handle_run_status(status, id, response, %__MODULE__{} = state) do
+    log("Run ID #{inspect(id)} failed with status #{inspect(status)}", :warning)
+    log("Response: #{inspect(response)}")
+    log("State: #{inspect(state)}")
+    noreply(%{state | running?: false, run_id: nil})
   end
 
   defmodule Impl do


### PR DESCRIPTION
This pull request fixes the handling of run status in the GptAgent module. It sets the running? flag to false when a run fails, expires, or is cancelled. It also ensures that the check_run_status message is handled when sent via continuation. Additionally, it adds the functionality to retrieve the existing run status when connecting to a thread with a run history.