### PR TITLE
Require last_message_id when connecting to an agent

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GptAgent.MixProject do
   def project do
     [
       app: :gpt_agent,
-      version: "5.1.1",
+      version: "6.0.0",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
This pull request adds a new requirement for the `last_message_id` parameter when connecting to an agent. It must always be explicitly set, even if it is set to `nil`. This ensures that client code is proactively setting the value, preventing situations where an old value is used and later messages are not displayed.