### PR TITLE
Handle Reconnecting to Thread with Run In Progress

### DIFF
--- a/lib/gpt_agent.ex
+++ b/lib/gpt_agent.ex
@@ -50,7 +50,6 @@ defmodule GptAgent do
   @callback submit_tool_output(pid(), Types.tool_name(), Types.tool_output()) ::
               Types.result(:invalid_tool_call_id)
 
-  defp ok(%__MODULE__{} = state), do: {:ok, state, state.timeout_ms}
   defp noreply(%__MODULE__{} = state), do: {:noreply, state, state.timeout_ms}
   defp noreply(%__MODULE__{} = state, next), do: {:noreply, state, next}
   defp reply(%__MODULE__{} = state, reply), do: {:reply, reply, state, state.timeout_ms}
@@ -78,7 +77,7 @@ defmodule GptAgent do
     state
     |> register()
     |> retrieve_current_run_status()
-    |> ok()
+    |> then(&{:ok, &1, {:continue, {:check_run_status, &1.run_id}}})
   end
 
   defp register(%__MODULE__{} = state) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GptAgent.MixProject do
   def project do
     [
       app: :gpt_agent,
-      version: "6.0.1",
+      version: "6.0.2",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
This pull request fixes the issue #16 by implementing the necessary changes to handle reconnecting to a thread with a run in progress. The changes include retrieving the current run state and emitting the necessary events to inform subscribers about tool calls that were requested. This prevents the thread from getting stuck in a waiting state and allows for continued interaction.